### PR TITLE
New option: `-d` to support custom delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ echo "v1: {{ .key1 }}" | datasubst --json-data examples/basic-data.json
 # Using stdin - YAML
 echo "v3: {{ .key2.first.key3 }}" | datasubst --yaml-data examples/basic-data.yaml
 # Using stdin - env
-echo "example: {{ .VAR3 }}" | VAR3="v3" datasubst --env-data
+echo "{{ .TEST1 }} {{ .TEST2 }}" | TEST1="hello" TEST2="world" datasubst --env-data
+
+# Using additional options, such -s (strict mode) and -d (change delimiters)
+echo "(( .TEST ))" | TEST="hi" datasubst --env-data -d '((:))' -s
 ```
 
 See [examples](./examples/) for more.


### PR DESCRIPTION
## 📃 What

Introduces new option: `-d`/`--delimiters` to support custom delimiters

**Caveat**: in this implementation, we do not allow the character `:` to be used as a delimiter since that is the separator used to split the delimiters passed via the `-d` option.

## 🤔 Why

Additional flexibility when your input contains `{{`/`}}` that should not be considered part of the template.